### PR TITLE
add permitted languages to code blocks and allowed html in md

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -71,7 +71,16 @@
   },
   "MD032": true,
   "MD033": {
-    "allowed_elements": []
+    "allowed_elements": [
+      "blockquote",
+      "code",
+      "div",
+      "h1",
+      "h2",
+      "h3",
+      "kbd",
+      "span"
+    ]
   },
   "MD034": true,
   "MD035": {
@@ -84,7 +93,33 @@
   "MD038": true,
   "MD039": true,
   "MD040": {
-    "allowed_languages": [],
+    "allowed_languages": [
+      "bash",
+      "c",
+      "c++",
+      "cpp",
+      "c#",
+      "csharp",
+      "css",
+      "django",
+      "dockerfile",
+      "html",
+      "java",
+      "javascript",
+      "json",
+      "latex",
+      "markdown",
+      "pgsql",
+      "plaintext",
+      "powershell",
+      "python",
+      "scss",
+      "shell",
+      "sql",
+      "typescript",
+      "xml",
+      "yaml"
+    ],
     "language_only": true
   },
   "MD041": {
@@ -98,7 +133,8 @@
   },
   "MD044": {
     "names": [
-      "JavaScript"
+      "JavaScript",
+      "GitHub"
     ],
     "code_blocks": false,
     "html_elements": false

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This tool checks for formatting issues in markdown files using GA's markdown linting template. To use it:
 
 - Create a JavaScript file in the root of your project.
-- Install this tool with `npm i `
+- Install this tool with `npm i ga-mdlint`
 - Add this code to your JavaScript file:
-  
+
   ```javascript
   import { runLinter } from "ga-mdlint"
 
@@ -13,6 +13,7 @@ This tool checks for formatting issues in markdown files using GA's markdown lin
 
   ```
 
+- Run the file!
 
 Rule explanations:
 
@@ -20,25 +21,35 @@ Rule explanations:
 {
   "default": true,
 
-  // MD001/heading-increment : Heading levels should only increment by one level at a time : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md001.md
+  // MD001/heading-increment
+  // Heading levels should only increment by one level at a time
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md001.md
   "MD001": true,
 
-  // MD003/heading-style : Heading style : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md003.md
+  // MD003/heading-style
+  // Heading style
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md003.md
   "MD003": {
     // Heading style
     "style": "atx" // Heading lines start with `#`
   },
 
-  // MD004/ul-style : Unordered list style : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md004.md
+  // MD004/ul-style 
+  // Unordered list style
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md004.md
   "MD004": {
     // List style
     "style": "dash" // list items start with a dash
   },
 
-  // MD005/list-indent : Inconsistent indentation for list items at the same level : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md005.md
+  // MD005/list-indent
+  // Inconsistent indentation for list items at the same level
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md005.md
   "MD005": true,
 
-  // MD007/ul-indent : Unordered list indentation : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md007.md
+  // MD007/ul-indent
+  // Unordered list indentation
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md007.md
   "MD007": {
     // Spaces for indent
     "indent": 2,
@@ -46,7 +57,9 @@ Rule explanations:
     "start_indented": false,
   },
 
-  // MD009/no-trailing-spaces : Trailing spaces : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md009.md
+  // MD009/no-trailing-spaces
+  // Trailing spaces
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md009.md
   "MD009": {
     // Spaces for line break
     "br_spaces": 0, // Spaces should not be used to create breaks
@@ -56,9 +69,12 @@ Rule explanations:
     "strict": true
   },
 
-  // MD010/no-hard-tabs : Hard tabs : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md010.md
+  // MD010/no-hard-tabs
+  // Hard tabs
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md010.md
 
-  // Hard tabs are rendered inconsistently by GH. Tabs should be converted to spaces on save.
+  // Hard tabs are rendered inconsistently by GitHub. 
+  // Tabs should be converted to spaces on save.
   "MD010": {
     // Include code blocks
     "code_blocks": true,
@@ -68,23 +84,36 @@ Rule explanations:
     "spaces_per_tab": 2
   },
 
-  // MD011/no-reversed-links : Reversed link syntax : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md011.md
+  // MD011/no-reversed-links
+  // Reversed link syntax
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md011.md
   "MD011": true, // Ensures link syntax is correct
 
-  // MD012/no-multiple-blanks : Multiple consecutive blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md012.md
+  // MD012/no-multiple-blanks 
+  // Multiple consecutive blank lines
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md012.md
   "MD012": {
     // Consecutive blank lines
-    "maximum": 1 // Except in a code block, blank lines serve no purpose and do not affect the rendering of content.
+    "maximum": 1 
+    // Except in a code block, blank lines serve no purpose and do not affect 
+    // the rendering of content.
   },
 
-  // MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md013.md
+  // MD013/line-length
+  // Line length
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md013.md
   "MD013": {
     // Number of characters
-    "line_length": 500, // Strongly consider breaking up long lines of text into multiple lines to increase readability.
+    "line_length": 500, 
+    // Strongly consider breaking up long lines of text into multiple 
+    // lines to increase readability.
     // Number of characters for headings
     "heading_line_length": 80, // Headings should generally be fewer than 80 characters.
     // Number of characters for code blocks
-    "code_block_line_length": 80, // Lines in code blocks should be fewer than 80 characters to ensure readability when browsers are at half screen width on laptop displays. Split code across lines when possible.
+    "code_block_line_length": 80, 
+    // Lines in code blocks should be fewer than 80 characters to ensure 
+    // readability when browsers are at half screen width on laptop displays.
+    // Split code across lines when possible.
     // Include code blocks
     "code_blocks": true,
     // Include tables
@@ -97,22 +126,34 @@ Rule explanations:
     "stern": false
   },
 
-  // MD014/commands-show-output : Dollar signs used before commands without showing output : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md014.md
+  // MD014/commands-show-output
+  // Dollar signs used before commands without showing output
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md014.md
   "MD014": true,
 
-  // MD018/no-missing-space-atx : No space after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md018.md
+  // MD018/no-missing-space-atx
+  // No space after hash on atx style heading
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md018.md
   "MD018": true,
 
-  // MD019/no-multiple-space-atx : Multiple spaces after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md019.md
+  // MD019/no-multiple-space-atx
+  // Multiple spaces after hash on atx style heading
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md019.md
   "MD019": true,
 
-  // MD020/no-missing-space-closed-atx : No space inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md020.md
+  // MD020/no-missing-space-closed-atx
+  // No space inside hashes on closed atx style heading
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md020.md
   "MD020": true, // Shouldn't exist, but is part of the default config.
 
-  // MD021/no-multiple-space-closed-atx : Multiple spaces inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md021.md
+  // MD021/no-multiple-space-closed-atx
+  // Multiple spaces inside hashes on closed atx style heading
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md021.md
   "MD021": true, // Shouldn't exist, but is part of the default config.
 
-  // MD022/blanks-around-headings : Headings should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md022.md
+  // MD022/blanks-around-headings
+  // Headings should be surrounded by blank lines
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md022.md
   "MD022": {
     // Blank lines above heading
     "lines_above": 1, // Does not apply at the start of a document
@@ -120,40 +161,61 @@ Rule explanations:
     "lines_below": 1
   },
 
-  // MD023/heading-start-left : Headings must start at the beginning of the line : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md023.md
+  // MD023/heading-start-left
+  // Headings must start at the beginning of the line
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md023.md
   "MD023": true,
 
-  // MD024/no-duplicate-heading : Multiple headings with the same content : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md024.md
+  // MD024/no-duplicate-heading
+  // Multiple headings with the same content
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md024.md
   "MD024": {
     // Only check sibling headings
     "siblings_only": true
   },
 
-  // MD025/single-title/single-h1 : Multiple top-level headings in the same document : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md025.md
+  // MD025/single-title/single-h1
+  // Multiple top-level headings in the same document
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md025.md
   "MD025": {
     // Heading level
     "level": 1, // Documents can only have one title - the text of an H1 header.
   },
 
-  // MD026/no-trailing-punctuation : Trailing punctuation in heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md026.md
+  // MD026/no-trailing-punctuation
+  // Trailing punctuation in heading
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md026.md
   "MD026": {
     // Punctuation characters
     "punctuation": ".,;:。，；："
   },
 
-  // MD027/no-multiple-space-blockquote : Multiple spaces after blockquote symbol : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md027.md
+  // MD027/no-multiple-space-blockquote
+  // Multiple spaces after blockquote symbol
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md027.md
   "MD027": true,
 
-  // MD028/no-blanks-blockquote : Blank line inside blockquote : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md028.md
-  "MD028": true, // Some Markdown parsers will treat two blockquotes separated by one or more blank lines as the same blockquote, while others will treat them as separate blockquotes.
+  // MD028/no-blanks-blockquote
+  // Blank line inside blockquote
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md028.md
+  "MD028": true, 
+  // Some Markdown parsers will treat two blockquotes separated by one or 
+  // more blank lines as the same blockquote, while others will treat them 
+  // as separate blockquotes.
 
-  // MD029/ol-prefix : Ordered list item prefix : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md029.md
+  // MD029/ol-prefix
+  // Ordered list item prefix
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md029.md
   "MD029": {
     // List style
-    "style": "one_or_ordered" // Prefer to specifically number lists, but a list of ones is allowed, and encouraged for longer lists.
+    "style": "one_or_ordered" 
+    // Prefer to specifically number lists, but a list of ones is allowed, 
+    // and encouraged for longer lists.
   },
 
-  // MD030/list-marker-space : Spaces after list markers : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md030.md
+  // MD030/list-marker-space
+  // Spaces after list markers
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md030.md
   "MD030": {
     // Spaces for single-line unordered list items
     "ul_single": 1,
@@ -163,57 +225,117 @@ Rule explanations:
     "ul_multi": 3,
     // Spaces for multi-line ordered list items
     "ol_multi": 2
-    // See: https://cirosantilli.com/markdown-style-guide/#spaces-after-list-marker for rationale for the above.
+    // See: 
+    // https://cirosantilli.com/markdown-style-guide/#spaces-after-list-marker 
+    // for rationale for the above.
   },
 
-  // MD031/blanks-around-fences : Fenced code blocks should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md031.md
+  // MD031/blanks-around-fences
+  // Fenced code blocks should be surrounded by blank lines
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md031.md
   "MD031": {
     // Include list items
     "list_items": true
   },
 
-  // MD032/blanks-around-lists : Lists should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md032.md
+  // MD032/blanks-around-lists
+  // Lists should be surrounded by blank lines
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md032.md
   "MD032": true,
 
-  // MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md033.md
+  // MD033/no-inline-html
+  // Inline HTML
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md033.md
   "MD033": {
     // Allowed elements
-    "allowed_elements": []
+    "allowed_elements": [
+      "blockquote",
+      "code",
+      "div",
+      "h1",
+      "h2",
+      "h3",
+      "kbd",
+      "p",
+      "span"
+    ]
   },
 
-  // MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md034.md
+  // MD034/no-bare-urls
+  // Bare URL used
+  /// https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md034.md
   "MD034": true,
 
-  // MD035/hr-style : Horizontal rule style : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md035.md
+  // MD035/hr-style
+  // Horizontal rule style
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md035.md
   "MD035": {
     // Horizontal rule style
     "style": "---"
   },
 
-  // MD036/no-emphasis-as-heading : Emphasis used instead of a heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md036.md
+  // MD036/no-emphasis-as-heading
+  // Emphasis used instead of a heading
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md036.md
   "MD036": {
     // Punctuation characters
     "punctuation": ".,;:!?。，；：！？"
   },
 
-  // MD037/no-space-in-emphasis : Spaces inside emphasis markers : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md037.md
+  // MD037/no-space-in-emphasis
+  // Spaces inside emphasis markers
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md037.md
   "MD037": true,
 
-  // MD038/no-space-in-code : Spaces inside code span elements : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md038.md
+  // MD038/no-space-in-code
+  // Spaces inside code span elements
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md038.md
   "MD038": true,
   
-  // MD039/no-space-in-links : Spaces inside link text : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md039.md
+  // MD039/no-space-in-links
+  // Spaces inside link text
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md039.md
   "MD039": true,
 
-  // MD040/fenced-code-language : Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md040.md
+  // MD040/fenced-code-language
+  // Fenced code blocks should have a language specified
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md040.md
   "MD040": {
     // List of languages
-    "allowed_languages": [],
+    "allowed_languages": [
+      "bash",
+      "c",
+      "c++",
+      "cpp",
+      "c#",
+      "csharp",
+      "css",
+      "django",
+      "dockerfile",
+      "html",
+      "java",
+      "javascript",
+      "json",
+      "latex",
+      "markdown",
+      "pgsql",
+      "plaintext",
+      "powershell",
+      "python",
+      "scss",
+      "shell",
+      "sql",
+      "typescript",
+      "xml",
+      "yaml"
+    ],
     // Require language only
     "language_only": true
   },
 
-  // MD041/first-line-heading/first-line-h1 : First line in a file should be a top-level heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md041.md
+  // MD041/first-line-heading/first-line-h1
+  // First line in a file should be a top-level heading
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md041.md
   "MD041": {
     // Heading level
     "level": 1, // h1 should always be on the first line of a document
@@ -221,10 +343,14 @@ Rule explanations:
     "front_matter_title": "^\\s*title\\s*[:=]"
   },
 
-  // MD042/no-empty-links : No empty links : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md042.md
+  // MD042/no-empty-links
+  // No empty links
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md042.md
   "MD042": true,
 
-  // MD043/required-headings : Required heading structure : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md043.md
+  // MD043/required-headings
+  // Required heading structure
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md043.md
   "MD043": {
     // List of headings
     "headings": ["*"], // We do not enforce docs to have specific headers
@@ -232,7 +358,9 @@ Rule explanations:
     "match_case": false
   },
 
-  // MD044/proper-names : Proper names should have the correct capitalization : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md044.md
+  // MD044/proper-names
+  // Proper names should have the correct capitalization
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md044.md
   "MD044": {
     // List of proper names
     "names": [
@@ -244,46 +372,64 @@ Rule explanations:
     "html_elements": false
   },
 
-  // MD045/no-alt-text : Images should have alternate text (alt text) : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md045.md
+  // MD045/no-alt-text
+  // Images should have alternate text (alt text)
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md045.md
   "MD045": true,
 
-  // MD046/code-block-style : Code block style : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md046.md
+  // MD046/code-block-style
+  // Code block style
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md046.md
   "MD046": {
     // Block style
     "style": "fenced" // Fenced code blocks should always be used.
   },
 
-  // MD047/single-trailing-newline : Files should end with a single newline character : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md047.md
+  // MD047/single-trailing-newline
+  // Files should end with a single newline character
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md047.md
   "MD047": true,
 
-  // MD048/code-fence-style : Code fence style : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md048.md
+  // MD048/code-fence-style
+  // Code fence style
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md048.md
   "MD048": {
     // Code fence style
     "style": "backtick" // Fenced code blocks should always use backticks
   },
 
-  // MD049/emphasis-style : Emphasis style : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md049.md
+  // MD049/emphasis-style
+  // Emphasis style
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md049.md
   "MD049": {
     // Emphasis style
     "style": "asterisk" // Asterisks should be used for emphasis
   },
 
-  // MD050/strong-style : Strong style : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md050.md
+  // MD050/strong-style
+  // Strong style
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md050.md
   "MD050": {
     // Strong style
     "style": "asterisk" // Asterisks should be used to bold text
   },
 
-  // MD051/link-fragments : Link fragments should be valid : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md051.md
+  // MD051/link-fragments
+  // Link fragments should be valid
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md051.md
   "MD051": true,
 
-  // MD052/reference-links-images : Reference links and images should use a label that is defined : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md052.md
+  // MD052/reference-links-images
+  // Reference links and images should use a label that is defined
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md052.md
   "MD052": {
     // Include shortcut syntax
     "shortcut_syntax": false
   },
 
-  // MD053/link-image-reference-definitions : Link and image reference definitions should be needed : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md053.md
+  // MD053/link-image-reference-definitions
+  // Link and image reference definitions should be needed
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md053.md
   "MD053": {
     // Ignored definitions
     "ignored_definitions": [
@@ -291,7 +437,9 @@ Rule explanations:
     ]
   },
 
-  // MD054/link-image-style : Link and image style : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md054.md
+  // MD054/link-image-style
+  // Link and image style
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md054.md
   "MD054": {
     // Allow autolinks
     "autolink": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga-mdlint",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Lint rules and CLI tool used for Markdown files at General Assembly",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This release will:
- Change `MD040` to require specific languages to be used in code blocks.
  - This will cause invalid languages to be flagged when authors attempt to use them.
- Change `MD033` to allow certain HTML elements to be used in markdown files.
  - This will allow us to construct HTML banners and other new components without them being flagged in markdown.
  - There is some implicit risk here, but this will hopefully strike a balance between allowing all HTML or flagging valid HTML we expect authors to use.
- Fix some file formatting issues.